### PR TITLE
fix(card): Set image loading to eager to resolve dependency issue

### DIFF
--- a/config/core.entity_view_display.media.image.card.yml
+++ b/config/core.entity_view_display.media.image.card.yml
@@ -21,10 +21,10 @@ content:
       responsive_image_style: card_responsive
       image_link: ''
       image_loading:
-        attribute: lazy
+        attribute: eager
     third_party_settings:
       lazy:
-        lazy_image: '1'
+        lazy_image: '0'
         placeholder_style: ''
         data_uri: false
     weight: 0


### PR DESCRIPTION
Switches the card image loading strategy from "lazy" to "eager" to fix a broken image display caused by a missing third-party JavaScript library (lazysizes.js).

The `lazy` module was correctly modifying the image attributes on the backend, but the corresponding frontend JavaScript was not present in the environment, leading to a 404 error and preventing images from loading.

This commit resolves the issue by:
- Setting the native `loading` attribute to `eager` in the media view display.
- Explicitly disabling the `lazy` module's intervention for this specific view mode.

This ensures the card image renders reliably without relying on an external library that is not correctly installed in the current build.